### PR TITLE
Created CRUD endpoints and schemas

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -7,6 +7,7 @@ from argon2 import PasswordHasher
 import sys
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
@@ -15,7 +16,6 @@ class User(db.Model):
     created_at = db.Column(
         db.DateTime, nullable=False, default=datetime.now(timezone.utc)
     )
-
 
 class UserSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
@@ -35,8 +35,6 @@ class CreateUserSchema(ma.Schema):
     password = fields.String(required=True, validate=validate_password)
     class Meta:
         unknown = EXCLUDE
-
-auth_bp = Blueprint("auth", __name__, url_prefix=None)
 
 @auth_bp.route("/register", methods=["POST"])
 def register():

--- a/server/products.py
+++ b/server/products.py
@@ -1,6 +1,9 @@
 from app import db, ma
 from datetime import datetime, timezone
 from flask import Blueprint, jsonify, request
+from sqlalchemy.exc import IntegrityError
+
+products_bp = Blueprint("product", __name__, url_prefix='/products')
 
 class Tag(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
@@ -40,4 +43,112 @@ class SwipeHistory(db.Model):
         db.DateTime, nullable=False, default=datetime.now(timezone.utc)
     )
 
-products_bp = Blueprint("product", __name__, url_prefix=None)
+# Schemas for serialization/deserialization
+class ProductSchema(ma.SQLAlchemyAutoSchema):
+    Category = ma.Nested('CategorySchema')
+    class Meta:
+        model = Product
+
+class CategorySchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Category
+
+class TagSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Tag
+
+product_schema = ProductSchema()
+products_schema = ProductSchema(many=True)
+category_schema = CategorySchema()
+categories_schema = CategorySchema(many=True)
+tag_schema = TagSchema()
+tags_schema = TagSchema(many=True)
+
+# Product CRUD Endpoints
+
+# CREATE Product
+@products_bp.route('/', methods=['POST'])
+def create_product():
+    data = request.get_json()
+    new_product = Product(
+        name=data['name'],
+        price=data['price'],
+        category_id=data['category_id']
+    )
+    db.session.add(new_product)
+    db.session.commit()
+    return jsonify({"message": "Product created successfully", "product": product_schema.dump(new_product)}), 201
+
+# READ all Products
+@products_bp.route('/', methods=['GET'])
+def get_products():
+    products = Product.query.all()
+    return jsonify(products_schema.dump(products)), 200
+
+# READ single Product by ID
+@products_bp.route('/<int:id>', methods=['GET'])
+def get_product(id):
+    product = Product.query.get_or_404(id)
+    return jsonify(product_schema.dump(product)), 200
+
+# UPDATE Product
+@products_bp.route('/<int:id>', methods=['PUT'])
+def update_product(id):
+    data = request.get_json()
+    product = Product.query.get_or_404(id)
+    product.name = data.get('name', product.name)
+    product.price = data.get('price', product.price)
+    product.category_id = data.get('category_id', product.category_id)
+    db.session.commit()
+    return jsonify({"message": "Product updated successfully", "product": product_schema.dump(product)}), 200
+
+# DELETE Product
+@products_bp.route('/<int:id>', methods=['DELETE'])
+def delete_product(id):
+    product = Product.query.get_or_404(id)
+    db.session.delete(product)
+    db.session.commit()
+    return jsonify({"message": "Product deleted successfully"}), 200
+
+# Category CRUD Endpoints
+
+# CREATE Category
+@products_bp.route('/categories', methods=['POST'])
+def create_category():
+    data = request.get_json()
+    new_category = Category(name=data['name'], description=data.get('description'))
+    db.session.add(new_category)
+    db.session.commit()
+    return jsonify({"message": "Category created successfully", "category": category_schema.dump(new_category)}), 201
+
+# READ all Categories
+@products_bp.route('/categories', methods=['GET'])
+def get_categories():
+    categories = Category.query.all()
+    return jsonify(categories_schema.dump(categories)), 200
+
+# DELETE Category
+@products_bp.route('/categories/<int:id>', methods=['DELETE'])
+def delete_category(id):
+    category = Category.query.get_or_404(id)
+    db.session.delete(category)
+    db.session.commit()
+    return jsonify({"message": "Category deleted successfully"}), 200
+
+# Tag CRUD Endpoints
+
+# CREATE Tag
+@products_bp.route('/tags', methods=['POST'])
+def create_tag():
+    data = request.get_json()
+    new_tag = Tag(name=data['name'])
+    db.session.add(new_tag)
+    db.session.commit()
+    return jsonify({"message": "Tag created successfully", "tag": tag_schema.dump(new_tag)}), 201
+
+# READ all Tags
+@products_bp.route('/tags', methods=['GET'])
+def get_tags():
+    tags = Tag.query.all()
+    return jsonify(tags_schema.dump(tags)), 200
+

--- a/server/products.py
+++ b/server/products.py
@@ -2,6 +2,7 @@ from app import db, ma
 from datetime import datetime, timezone
 from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import IntegrityError
+from auth import User
 
 products_bp = Blueprint("product", __name__, url_prefix='/products')
 


### PR DESCRIPTION
created CRUD endpoints and schemas for Product, Category, and Tag

- Added Blueprint with `/products` prefix for structured routing.
- Implemented CRUD endpoints for `Product`, `Category`, and `Tag` models.
- Created SQLAlchemy schemas for serialization, including nested `CategorySchema` in `ProductSchema`.
- Added response messages for create, update, and delete actions.
